### PR TITLE
Fix typo in product generator agent

### DIFF
--- a/3d_objects/agents/src/product_generator_agent.py
+++ b/3d_objects/agents/src/product_generator_agent.py
@@ -111,7 +111,7 @@ async def generate_product(color, output_dir="."):
             Did the AI agent comply with the requirements?  
             
             The most important aspect is to make sure the appropriate number of puzzle pieces are separated by the {border} border.
-            If the number of pieces is acheived and the color scheme is roughly in the ballpark, the image is considered good enough.
+            If the number of pieces is achieved and the color scheme is roughly in the ballpark, the image is considered good enough.
 
             Respond "yes" or "no".
 


### PR DESCRIPTION
## Summary
- fix a typo in evaluation instructions of `product_generator_agent.py`

## Testing
- `python -m py_compile 3d_objects/agents/src/product_generator_agent.py`


------
https://chatgpt.com/codex/tasks/task_e_68482e57de90832285b395ad1ddba466