### PR TITLE
Fix argument handling for Zarr output

### DIFF
--- a/azure_anemoi/data_import_component/src/data_import_component.py
+++ b/azure_anemoi/data_import_component/src/data_import_component.py
@@ -1,10 +1,29 @@
-import xarray as xr
+"""Utility script that writes a subset of a reference Zarr archive to disk.
+
+The output directory path must be provided as the first command line argument. If
+no argument is supplied the script exits with a usage message.
+"""
+
 import sys
+import xarray as xr
 
-output_zarr = sys[0]
 
-ds = xr.open_zarr("https://storage.googleapis.com/noaa-ufs-gefsv13replay/ufs-hr1/0.25-degree/03h-freq/zarr/fv3.zarr/")
+def main() -> None:
+    """Export a single time slice of the sample dataset to the given Zarr path."""
 
-ds_small = ds.sel(time="2023-01-01T00:00")
+    if len(sys.argv) < 2:
+        print("Usage: python data_import_component.py <output_zarr_path>")
+        sys.exit(1)
 
-ds_small.to_zarr(output_zarr)
+    output_zarr = sys.argv[1]
+
+    ds = xr.open_zarr(
+        "https://storage.googleapis.com/noaa-ufs-gefsv13replay/ufs-hr1/0.25-degree/03h-freq/zarr/fv3.zarr/"
+    )
+    ds_small = ds.sel(time="2023-01-01T00:00")
+
+    ds_small.to_zarr(output_zarr)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- improve usage instructions for `data_import_component.py`
- handle missing output path argument

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68482ed217108322a9e88e0a62f3dd53