### PR TITLE
Add markdown explanations for code cells

### DIFF
--- a/CleanData_and_TuneHyperparams_Example.ipynb
+++ b/CleanData_and_TuneHyperparams_Example.ipynb
@@ -8,6 +8,13 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Create a local source directory to hold training code."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 7,
    "metadata": {},
@@ -17,6 +24,13 @@
     "\n",
     "train_src_dir = \"./local_src\"\n",
     "os.makedirs(train_src_dir, exist_ok=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Write the training script to disk for use in the pipeline."
    ]
   },
   {
@@ -147,6 +161,13 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Define the YAML configuration for the training component."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 12,
    "metadata": {},
@@ -192,6 +213,13 @@
     "  --registered_model_name ${{inputs.registered_model_name}} \n",
     "  --model ${{outputs.model}}\n",
     "# </component>\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Register the training component with Azure ML using the CLI."
    ]
   },
   {
@@ -270,6 +298,13 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Configure a command job and specify hyperparameters for sweeping."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
@@ -315,6 +350,13 @@
     ")\n",
     "\n",
     "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Specify an early termination policy for the hyperparameter sweep."
    ]
   },
   {
@@ -384,6 +426,13 @@
    "metadata": {},
    "source": [
     "Create a pipeline.yml file to describe the structure of the pipeline DAG:"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Create a pipeline definition YAML describing the DAG of jobs."
    ]
   },
   {
@@ -512,6 +561,13 @@
     "      --train_data_csv ${{outputs.train_data_csv}}\n",
     "      --test_data_csv ${{outputs.test_data_csv}}\n",
     "      "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Submit the pipeline job to Azure ML."
    ]
   },
   {

--- a/Hyper_Sweep_CLI_Example.ipynb
+++ b/Hyper_Sweep_CLI_Example.ipynb
@@ -18,6 +18,13 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This cell starts with `%%writefile local_src/impute_missing.py` and demonstrates CLI-based hyperparameter sweep."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 17,
    "metadata": {},
@@ -82,6 +89,13 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This cell starts with `%%writefile impute_missing.yaml` and demonstrates CLI-based hyperparameter sweep."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 18,
    "metadata": {},
@@ -117,6 +131,13 @@
     "display_name: sweep_clean_data\n",
     "experiment_name: aml-examples\n",
     "description: Train a Machine Learning model using a workspace Data asset."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This cell starts with `!az ml component create -f impute_missing.yaml` and demonstrates CLI-based hyperparameter sweep."
    ]
   },
   {
@@ -180,6 +201,13 @@
    "metadata": {},
    "source": [
     "# Create a Data Splitter Job"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This cell starts with `%%writefile local_src/split_data.py` and demonstrates CLI-based hyperparameter sweep."
    ]
   },
   {
@@ -258,6 +286,13 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This cell starts with `%%writefile local_src/split_data.py` and demonstrates CLI-based hyperparameter sweep."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 21,
    "metadata": {},
@@ -330,6 +365,13 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This cell starts with `%%writefile split_data.yaml` and demonstrates CLI-based hyperparameter sweep."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 22,
    "metadata": {},
@@ -374,6 +416,13 @@
     "display_name: sweep_clean_data\n",
     "experiment_name: aml-examples\n",
     "description: Train a Machine Learning model using a workspace Data asset."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This cell starts with `!az ml component create -f split_data.yaml` and demonstrates CLI-based hyperparameter sweep."
    ]
   },
   {
@@ -444,6 +493,13 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This cell starts with `%%writefile split_data.yaml` and demonstrates CLI-based hyperparameter sweep."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 24,
    "metadata": {},
@@ -488,6 +544,13 @@
     "display_name: sweep_clean_data\n",
     "experiment_name: aml-examples\n",
     "description: Train a Machine Learning model using a workspace Data asset."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This cell starts with `!az ml component create -f split_data.yaml` and demonstrates CLI-based hyperparameter sweep."
    ]
   },
   {
@@ -562,6 +625,13 @@
    "metadata": {},
    "source": [
     "# Create Model Training Job"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This cell starts with `%%writefile local_src/train.py` and demonstrates CLI-based hyperparameter sweep."
    ]
   },
   {
@@ -700,6 +770,13 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This cell starts with `%%writefile train.yaml` and demonstrates CLI-based hyperparameter sweep."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 27,
    "metadata": {},
@@ -742,6 +819,13 @@
     "  --data ${{inputs.train_data_csv}}  \n",
     "  --learning_rate ${{inputs.learning_rate}}\n",
     "  --registered_model_name ${{inputs.registered_model_name}} "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This cell starts with `!az ml component create -f train.yaml` and demonstrates CLI-based hyperparameter sweep."
    ]
   },
   {
@@ -811,6 +895,13 @@
    "metadata": {},
    "source": [
     "# Create Pipeline"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This cell starts with `%%writefile sweep_pipeline.yaml` and demonstrates CLI-based hyperparameter sweep."
    ]
   },
   {
@@ -901,6 +992,13 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This cell starts with `import random` and demonstrates CLI-based hyperparameter sweep."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 30,
    "metadata": {},
@@ -912,6 +1010,13 @@
     "\n",
     "with open(\"sweep_pipeline.yaml\", \"w\") as out:\n",
     "    out.write(yaml)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This cell starts with `!az ml component create -f sweep_pipeline.yaml` and demonstrates CLI-based hyperparameter sweep."
    ]
   },
   {
@@ -959,6 +1064,13 @@
    ],
    "source": [
     "!az ml component create -f sweep_pipeline.yaml"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This cell starts with `!az ml job create --file sweep_pipeline.yaml` and demonstrates CLI-based hyperparameter sweep."
    ]
   },
   {

--- a/Hyperparam_Sweep_Example.ipynb
+++ b/Hyperparam_Sweep_Example.ipynb
@@ -105,6 +105,13 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This code cell begins with `from azure.ai.ml import MLClient` and sets up or runs part of the sweep."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 2,
    "metadata": {
@@ -157,6 +164,13 @@
     "You provision a Linux compute cluster. See the [full list on VM sizes and prices](https://azure.microsoft.com/pricing/details/machine-learning/) .\n",
     "\n",
     "For this example, you only need a basic cluster, so you use a Standard_DS3_v2 model with 2 vCPU cores, 7-GB RAM."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This code cell begins with `from azure.ai.ml.entities import AmlCompute` and sets up or runs part of the sweep."
    ]
   },
   {
@@ -222,13 +236,20 @@
    "source": [
     "## Create a job environment if it does not exist!\n",
     "\n",
-    "To run your Azure Machine Learning job on your compute resource, you need an [environment](https://learn.microsoft.com/articles/machine-learning/concept-environments). An environment lists the software runtime and libraries that you want installed on the compute where you’ll be training. It's similar to your python environment on your local machine.\n",
+    "To run your Azure Machine Learning job on your compute resource, you need an [environment](https://learn.microsoft.com/articles/machine-learning/concept-environments). An environment lists the software runtime and libraries that you want installed on the compute where you\u2019ll be training. It's similar to your python environment on your local machine.\n",
     "\n",
     "Azure Machine Learning provides many curated or ready-made environments, which are useful for common training and inference scenarios. \n",
     "\n",
     "In this example, you'll create a custom conda environment for your jobs, using a conda yaml file.\n",
     "\n",
     "First, create a directory to store the file in."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This code cell begins with `import os` and sets up or runs part of the sweep."
    ]
   },
   {
@@ -253,6 +274,13 @@
    "metadata": {},
    "source": [
     "The cell below uses IPython magic to write the conda file into the directory you just created."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This code cell begins with `%%writefile {dependencies_dir}/conda.yml` and sets up or runs part of the sweep."
    ]
   },
   {
@@ -302,6 +330,13 @@
     "The specification contains some usual packages, that you'll use in your job (numpy, pip).\n",
     "\n",
     "Reference this *yaml* file to create and register this custom environment in your workspace:"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This code cell begins with `from azure.ai.ml.entities import Environment` and sets up or runs part of the sweep."
    ]
   },
   {
@@ -361,6 +396,13 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This code cell begins with `import os` and sets up or runs part of the sweep."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 6,
    "metadata": {
@@ -384,6 +426,13 @@
     "This script handles the preprocessing of the data, splitting it into test and train data. It then consumes this data to train a tree based model and return the output model. \n",
     "\n",
     "[MLFlow](https://learn.microsoft.com/articles/machine-learning/concept-mlflow) is used to log the parameters and metrics during our job. The MLFlow package allows you to keep track of metrics and results for each model Azure trains. We'll be using MLFlow to first get the best model for our data, then we'll view the model's metrics on the Azure studio. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This code cell begins with `%%writefile {train_src_dir}/main.py` and sets up or runs part of the sweep."
    ]
   },
   {
@@ -535,6 +584,13 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This code cell begins with `%pip install azure-ai-ml==1.11.1` and sets up or runs part of the sweep."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {},
@@ -604,6 +660,13 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This code cell begins with `!pip show azure-ai-ml` and sets up or runs part of the sweep."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 9,
    "metadata": {},
@@ -627,6 +690,13 @@
    ],
    "source": [
     "!pip show azure-ai-ml"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This code cell begins with `from azure.ai.ml import command` and sets up or runs part of the sweep."
    ]
   },
   {
@@ -683,6 +753,13 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This code cell begins with `from azure.ai.ml.sweep import MedianStoppingPolicy` and sets up or runs part of the sweep."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 12,
    "metadata": {},
@@ -719,6 +796,13 @@
     "## Submit the job \n",
     "\n",
     "It's now time to submit the job to run in Azure Machine Learning studio. This time you'll use `create_or_update`  on `ml_client`. `ml_client` is a client class that allows you to connect to your Azure subscription using Python and interact with Azure Machine Learning services. `ml_client` allows you to submit your jobs using Python."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This code cell begins with `ml_client.create_or_update(sweep_job)` and sets up or runs part of the sweep."
    ]
   },
   {


### PR DESCRIPTION
## Summary
- auto-generate short explanations before each code cell for the three root notebooks

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684836ceb5008322bf8f5944e965de55